### PR TITLE
Some bugfixes

### DIFF
--- a/api/functions.php
+++ b/api/functions.php
@@ -19,7 +19,7 @@ function html_escape_array(&$arr, $inner_call=false, $pointer=false, $check_doub
         return $pointer ? NULL : $arr;
         
     foreach ($arr as $key => &$value) 
-        !is_array($value) ? html_escape_value_helper($value) : html_escape_array(&$value, true); 
+        !is_array($value) ? html_escape_value_helper($value) : html_escape_array($value, true); 
         
     if (!$inner_call) {
         if ($check_double_escape) $arr[0][0][100000] = true; 

--- a/api/functions.php
+++ b/api/functions.php
@@ -31,7 +31,7 @@ function html_escape_array(&$arr, $inner_call=false, $pointer=false, $check_doub
 function strip_color_codes($server) {
     $tmp = "";
     $skip = false;
-    for($i = 0; $i <= strlen($server); $i++) {
+    for($i = 0; $i < strlen($server); $i++) {
         $c = $server[$i];
         if ($c == "") { $skip = true; continue; }
         if ($skip) { $skip = false; continue; }


### PR DESCRIPTION
### Passing value instead of reference

`Fatal error: Call-time pass-by-reference has been removed in ac-info/api/functions.php on line 22`

You're passing parameters by reference on the function call, this isn't (anymore) supported in PHP.  
More info in the [PHP documentation](http://php.net/manual/en/language.references.pass.php):

> **There is no reference sign on a function call** - only on function definitions. Function definitions alone are enough to correctly pass the argument by reference. As of PHP 5.3.0, you will get a warning saying that "call-time pass-by-reference" is deprecated when you use & in foo(&$a);. And as of PHP 5.4.0, call-time pass-by-reference was removed, so using it will raise a fatal error.

### Loop

This bugfix is clear, I guess...